### PR TITLE
Fix bug where program crashes when a rectangular map is given

### DIFF
--- a/src/dynamicvoronoi.cpp
+++ b/src/dynamicvoronoi.cpp
@@ -26,7 +26,7 @@ void DynamicVoronoi::initializeEmpty(int _sizeX, int _sizeY, bool initGridMap) {
   sizeX = _sizeX;
   sizeY = _sizeY;
   if (data) {
-    for (int x=0; x<sizeX; x++) delete[] data[x];
+    for (int y=0; y<sizeY; y++) delete[] data[y];
     delete[] data;
   }
   data = new dataCell*[sizeX];


### PR DESCRIPTION
I've been playing around with the program and noticed that it crashes when I give it a non-square map. To reproduce, run the program with `map_large.png`. If you could confirm it that would be great.