### PR TITLE
Release gridMap memory

### DIFF
--- a/src/dynamicvoronoi.cpp
+++ b/src/dynamicvoronoi.cpp
@@ -60,6 +60,12 @@ void DynamicVoronoi::initializeEmpty(int _sizeX, int _sizeY, bool initGridMap) {
 }
 
 void DynamicVoronoi::initializeMap(int _sizeX, int _sizeY, bool** _gridMap) {
+  // release memory used by existing gridMap
+  if (gridMap) {
+    for (int x=0; x<sizeX; x++) delete[] gridMap[x];
+    delete[] gridMap;
+  }
+  
   gridMap = _gridMap;
   initializeEmpty(_sizeX, _sizeY, false);
 


### PR DESCRIPTION
In planner.cpp, we allocate memory for binMap and never release it. This is then passed to voronoiDiagram.initializeMap() function, which assigns it to the gridMap member variable.

In the subsequent calls to the function, we just assign this binMap or _gridMap parameter to the member variable gridMap, without releasing the existing gridMap memory. This results in memory leak.